### PR TITLE
Add AVPlayerItemObserverDelegate conformance in Tests

### DIFF
--- a/Example/Tests/AVPlayerItemObserverTests.swift
+++ b/Example/Tests/AVPlayerItemObserverTests.swift
@@ -49,8 +49,13 @@ class AVPlayerItemObserverTests: QuickSpec {
 class AVPlayerItemObserverDelegateHolder: AVPlayerItemObserverDelegate {
     
     var updateDuration: ((_ duration: Double) -> Void)?
+    var updateTimedMetaData: ((_ metaData: String) -> Void)?
     
     func item(didUpdateDuration duration: Double) {
         updateDuration?(duration)
+    }
+    
+    func item(didUpdateTimedMetadata metadata: String) {
+        updateTimedMetaData?(metadata)
     }
 }

--- a/Example/Tests/AVPlayerWrapperTests.swift
+++ b/Example/Tests/AVPlayerWrapperTests.swift
@@ -200,6 +200,7 @@ class AVPlayerWrapperDelegateHolder: AVPlayerWrapperDelegate {
     
     var stateUpdate: ((_ state: AVPlayerWrapperState) -> Void)?
     var didUpdateDuration: ((_ duration: Double) -> Void)?
+    var didUpdateTimedMetaData: ((_ metaData: String) -> Void)?
     var didSeekTo: ((_ seconds: Int) -> Void)?
     var itemDidComplete: (() -> Void)?
     
@@ -224,6 +225,10 @@ class AVPlayerWrapperDelegateHolder: AVPlayerWrapperDelegate {
             self.stateUpdate?(state)
         }
         didUpdateDuration?(duration)
+    }
+    
+    func AVWrapper(didUpdateTimedMetadata metadata: String) {
+        didUpdateTimedMetaData?(metadata)
     }
     
 }


### PR DESCRIPTION
The bitrise test build didn't compile due to the missing conformance to the AVPlayerItemObserverDelegate protocol. 